### PR TITLE
Search image resizing improvement

### DIFF
--- a/src/lib/bench.js
+++ b/src/lib/bench.js
@@ -1,0 +1,20 @@
+import { performance } from "perf_hooks";
+
+export function bench(name, func) {
+  const benchStart = performance.now();
+  const result = func();
+  const benchEnd = performance.now();
+  const benchTimeTaken = benchEnd - benchStart;
+  console.log(`${name} done in ${benchTimeTaken.toFixed(3)} ms`);
+  return result;
+}
+
+export async function benchAsync(name, func) {
+  const benchStart = performance.now();
+  const result = await func();
+  const benchEnd = performance.now();
+  const benchTimeTaken = benchEnd - benchStart;
+  console.log(`${name} done in ${benchTimeTaken.toFixed(3)} ms`);
+  return result;
+}
+

--- a/src/lib/bench.js
+++ b/src/lib/bench.js
@@ -17,4 +17,3 @@ export async function benchAsync(name, func) {
   console.log(`${name} done in ${benchTimeTaken.toFixed(3)} ms`);
   return result;
 }
-

--- a/src/search.js
+++ b/src/search.js
@@ -1,13 +1,9 @@
 import crypto from "node:crypto";
-import os from "node:os";
-import path from "node:path";
-import child_process from "node:child_process";
-import fs from "node:fs/promises";
 import aniep from "aniep";
 import cv from "@soruly/opencv4nodejs-prebuilt";
 import { performance } from "node:perf_hooks";
 import getSolrCoreList from "./lib/get-solr-core-list.js";
-import { bench, benchAsync } from "./lib/bench.js";
+import { bench } from "./lib/bench.js";
 
 const {
   TRACE_API_SALT,
@@ -101,7 +97,7 @@ const resizeImageForSearch = (sourceImage) => {
   }
 
   return cv.imencode(".jpg", image.resize(width, height));
-}
+};
 export default async (req, res) => {
   const locals = req.app.locals;
   const knex = req.app.locals.knex;

--- a/src/search.js
+++ b/src/search.js
@@ -370,7 +370,6 @@ export default async (req, res) => {
     rawDocsSearchTimeList.push(Number(RawDocsSearchTime));
     reRankSearchTimeList.push(Number(ReRankSearchTime));
     result = result.concat(response.docs);
-    console.log(`RawDocsSearchTime: ${RawDocsSearchTime}, ReRankSearchTime: ${ReRankSearchTime}`);
   }
 
   result = result

--- a/src/search.js
+++ b/src/search.js
@@ -85,7 +85,11 @@ const resizeImageForSearch = (sourceImage) => {
   let [height, width] = image.sizes;
 
   if (width <= 320 && height <= 320) {
-    return cv.imencode(".jpg", image);
+    try {
+      return cv.imencode(".jpg", image);
+    } catch (e) {
+      return false;
+    }
   }
 
   if (width > height) {
@@ -96,7 +100,11 @@ const resizeImageForSearch = (sourceImage) => {
     height = 320;
   }
 
-  return cv.imencode(".jpg", image.resize(width, height));
+  try {
+    return cv.imencode(".jpg", image.resize(width, height));
+  } catch (e) {
+    return false;
+  }
 };
 export default async (req, res) => {
   const locals = req.app.locals;
@@ -319,6 +327,7 @@ export default async (req, res) => {
     rawDocsSearchTimeList.push(Number(RawDocsSearchTime));
     reRankSearchTimeList.push(Number(ReRankSearchTime));
     result = result.concat(response.docs);
+    console.log(`RawDocsSearchTime: ${RawDocsSearchTime}, ReRankSearchTime: ${ReRankSearchTime}`);
   }
 
   result = result

--- a/src/search.js
+++ b/src/search.js
@@ -421,7 +421,8 @@ export default async (req, res) => {
     }
   }
 
-  await logAndDequeue(locals, uid, priority, 200, searchTime, result[0]?.similarity);
+  await logAndDequeue(locals, uid, priority, 200, searchTime, result[0]?.similarity ?? 0);
+
   res.json({
     frameCount: frameCountList.reduce((prev, curr) => prev + curr, 0),
     error: "",


### PR DESCRIPTION
Resizing with FFMpeg takes up a large amount of time due to it needing to spawn a process and read and write a file to disk.
After running benchmarks and an experiment I discovered that we can re-use the existing OpenCV library to speed the search up.
The benchmark results are listed below.

On my local machine it managed to reduce the image resize processing time from an average of 64,904ms to 4,409ms. ~14x faster.

FFMpeg has been replaced with OpenCV to resize images to the width of 320 pixels, retaining the aspect ratio and ensuring it is a jpg for the Solr instances. OpenCV supports most images formats that are used on the web.

> Currently, the following file formats are supported:

    Windows bitmaps - *.bmp, *.dib (always supported)
    JPEG files - *.jpeg, *.jpg, *.jpe (see the Note section)
    JPEG 2000 files - *.jp2 (see the Note section)
    Portable Network Graphics - *.png (see the Note section)
    WebP - *.webp (see the Note section)
    Portable image format - *.pbm, *.pgm, *.ppm *.pxm, *.pnm (always supported)
    Sun rasters - *.sr, *.ras (always supported)
    TIFF files - *.tiff, *.tif (see the Note section)
    OpenEXR Image files - *.exr (see the Note section)
    Radiance HDR - *.hdr, *.pic (always supported)
    Raster and Vector geospatial data supported by GDAL (see the Note section)

[Supported file formats Source](https://docs.opencv.org/3.4/d4/da8/group__imgcodecs.html)

FFMpeg Resize - Searches with warmed up Solr
```
2024-03-21 18:54:39 => 2024-03-21T17:54:39.063Z ::ffff:172.20.0.1 /search
2024-03-21 18:54:39 ffmpeg processing done in 65.158 ms
2024-03-21 18:54:39 <= 2024-03-21T17:54:39.149Z ::ffff:172.20.0.1 /search 200 86ms
//
2024-03-21 18:54:54 => 2024-03-21T17:54:54.736Z ::ffff:172.20.0.1 /search
2024-03-21 18:54:54 ffmpeg processing done in 64.448 ms
2024-03-21 18:54:54 <= 2024-03-21T17:54:54.866Z ::ffff:172.20.0.1 /search 200 130ms
//
2024-03-21 18:55:13 => 2024-03-21T17:55:13.861Z ::ffff:172.20.0.1 /search
2024-03-21 18:55:13 ffmpeg processing done in 65.107 ms
2024-03-21 18:55:14 <= 2024-03-21T17:55:14.025Z ::ffff:172.20.0.1 /search 200 163ms
```

OpenCV Resize - Searches with warmed up Solr
```
2024-03-21 19:02:14 => 2024-03-21T18:02:14.974Z ::ffff:172.20.0.1 /search
2024-03-21 19:02:14 image processing done in 6.016 ms
2024-03-21 19:02:15 <= 2024-03-21T18:02:15.025Z ::ffff:172.20.0.1 /search 200 52ms
//
2024-03-21 19:02:59 => 2024-03-21T18:02:59.043Z ::ffff:172.20.0.1 /search
2024-03-21 19:02:59 image processing done in 3.686 ms
2024-03-21 19:02:59 <= 2024-03-21T18:02:59.077Z ::ffff:172.20.0.1 /search 200 34ms
//
2024-03-21 19:03:22 => 2024-03-21T18:03:22.722Z ::ffff:172.20.0.1 /search
2024-03-21 19:03:22 image processing done in 3.525 ms
2024-03-21 19:03:22 <= 2024-03-21T18:03:22.761Z ::ffff:172.20.0.1 /search 200 39ms
```