### PR TITLE
Logging Viewed Media

### DIFF
--- a/server.js
+++ b/server.js
@@ -132,32 +132,35 @@ if (SOLA_DB_HOST) {
             }),
           ),
     ),
-    knex.schema.hasTable("scene_view_log").then(
-      (exists) =>
-        exists ||
-        knex.schema.createTable("scene_view_log", function (table) {
-          table.timestamp("time").notNullable().defaultTo(knex.fn.now());
-          table.integer("file_id").nullable();
-          table.float("start").notNullable();
-          table.float("end").notNullable();
-          table.float("duration").notNullable();
-          table.float("time_code").notNullable();
-          table.boolean("muted").notNullable();
-          table.string("size", 1).notNullable();
-        }),
-    ),
-    knex.schema.hasTable("scene_thumbnail_view_log").then(
-      (exists) =>
-        exists ||
-        knex.schema.createTable("scene_thumbnail_view_log", function (table) {
-          table.timestamp("time").notNullable().defaultTo(knex.fn.now());
-          table.integer("file_id").nullable();
-          table.float("time_code").notNullable();
-          table.string("size", 1).notNullable();
-        }),
-    ),
   ]);
 }
+
+await Promise.all([
+  knex.schema.hasTable("scene_view_log").then(
+    (exists) =>
+      exists ||
+      knex.schema.createTable("scene_view_log", function (table) {
+        table.timestamp("time").notNullable().defaultTo(knex.fn.now());
+        table.integer("file_id").nullable();
+        table.float("start").notNullable();
+        table.float("end").notNullable();
+        table.float("duration").notNullable();
+        table.float("time_code").notNullable();
+        table.boolean("muted").notNullable();
+        table.string("size", 1).notNullable();
+      }),
+  ),
+  knex.schema.hasTable("scene_thumbnail_view_log").then(
+    (exists) =>
+      exists ||
+      knex.schema.createTable("scene_thumbnail_view_log", function (table) {
+        table.timestamp("time").notNullable().defaultTo(knex.fn.now());
+        table.integer("file_id").nullable();
+        table.float("time_code").notNullable();
+        table.string("size", 1).notNullable();
+      }),
+  ),
+]);
 
 console.log("Cleaning up previous states");
 await Promise.all(

--- a/server.js
+++ b/server.js
@@ -132,6 +132,30 @@ if (SOLA_DB_HOST) {
             }),
           ),
     ),
+    knex.schema.hasTable("scene_view_log").then(
+      (exists) =>
+        exists ||
+        knex.schema.createTable("scene_view_log", function (table) {
+          table.timestamp("time").notNullable().defaultTo(knex.fn.now());
+          table.integer("file_id").nullable();
+          table.float("start").notNullable();
+          table.float("end").notNullable();
+          table.float("duration").notNullable();
+          table.float("time_code").notNullable();
+          table.boolean("muted").notNullable();
+          table.string("size", 1).notNullable();
+        }),
+    ),
+    knex.schema.hasTable("scene_thumbnail_view_log").then(
+      (exists) =>
+        exists ||
+        knex.schema.createTable("scene_thumbnail_view_log", function (table) {
+          table.timestamp("time").notNullable().defaultTo(knex.fn.now());
+          table.integer("file_id").nullable();
+          table.float("time_code").notNullable();
+          table.string("size", 1).notNullable();
+        }),
+    ),
   ]);
 }
 

--- a/server.js
+++ b/server.js
@@ -79,7 +79,8 @@ if (SOLA_DB_HOST) {
       (exists) =>
         exists ||
         knex.schema.createTable("file", function (table) {
-          table.string("path", 768).notNullable().primary();
+          table.increments("id").unsigned().notNullable().primary();
+          table.string("path", 768).notNullable().unique();
           table.enu("status", ["UPLOADED", "HASHING", "HASHED", "LOADING", "LOADED"]).notNullable();
           table.timestamp("created").notNullable().defaultTo(knex.fn.now());
           table.timestamp("updated").notNullable().defaultTo(knex.fn.now());

--- a/server.js
+++ b/server.js
@@ -93,8 +93,8 @@ if (SOLA_DB_HOST) {
           table.timestamp("time").notNullable().defaultTo(knex.fn.now());
           table.string("uid", 45).notNullable();
           table.smallint("status").unsigned().notNullable();
-          table.integer("search_time", 6).unsigned().notNullable();
-          table.float("accuracy", 20).unsigned().notNullable();
+          table.integer("search_time", 6).unsigned().nullable();
+          table.float("accuracy", 20).unsigned().nullable();
           table.index(["time", "uid", "status"], "time_uid_status");
         }),
     ),

--- a/sql/structure.sql
+++ b/sql/structure.sql
@@ -1,5 +1,3 @@
--- Adminer 4.8.1 MySQL 5.5.5-10.5.12-MariaDB dump
-
 SET NAMES utf8;
 SET time_zone = '+00:00';
 SET foreign_key_checks = 0;
@@ -8,16 +6,17 @@ SET sql_mode = 'NO_AUTO_VALUE_ON_ZERO';
 SET NAMES utf8mb4;
 
 CREATE TABLE IF NOT EXISTS `file` (
-  `path` varchar(768) COLLATE utf8mb4_unicode_ci NOT NULL,
-  `status` enum('UPLOADED','HASHING','HASHED','LOADING','LOADED') COLLATE utf8mb4_unicode_ci NOT NULL,
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `path` varchar(768) NOT NULL,
+  `status` enum('UPLOADED','HASHING','HASHED','LOADING','LOADED') NOT NULL,
   `created` timestamp NOT NULL DEFAULT current_timestamp(),
   `updated` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
-  PRIMARY KEY (`path`),
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `path` (`path`),
   KEY `status` (`status`),
   KEY `created` (`created`),
   KEY `updated` (`updated`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-
 
 CREATE TABLE IF NOT EXISTS `log` (
   `time` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00' ON UPDATE current_timestamp(),
@@ -311,5 +310,3 @@ CREATE ALGORITHM=UNDEFINED SQL SECURITY DEFINER VIEW `user_quota` AS select `log
 
 DROP TABLE IF EXISTS `user_view`;
 CREATE ALGORITHM=UNDEFINED SQL SECURITY DEFINER VIEW `user_view` AS select `user`.`id` AS `id`,`user`.`email` AS `email`,`user`.`api_key` AS `api_key`,`user`.`tier` AS `tier`,`tier`.`priority` AS `priority`,`tier`.`concurrency` AS `concurrency`,`tier`.`quota` AS `quota` from (`user` left join `tier` on(`user`.`tier` = `tier`.`id`));
-
--- 2021-12-06 03:55:26

--- a/src/image.js
+++ b/src/image.js
@@ -41,6 +41,17 @@ const generateImagePreview = async (filePath, t, size = "m") =>
     });
   });
 
+const logView = async (knex, filePath, size, t) => {
+  const fileId = (await knex("file").select("id").where("path", filePath).first()?.id) ?? null;
+
+  await knex("scene_thumbnail_view_log").insert({
+    time: knex.fn.now(),
+    file_id: fileId,
+    size: size,
+    time_code: t,
+  });
+};
+
 export default async (req, res) => {
   if (
     req.query.token !==
@@ -86,6 +97,10 @@ export default async (req, res) => {
   req.app.locals.mediaQueue++;
   try {
     const image = await generateImagePreview(videoFilePath, t, size);
+
+    const knex = req.app.locals.knex;
+    await logView(knex, videoFilePath, size, t);
+
     res.set("Content-Type", "image/jpg");
     res.send(image);
   } catch (e) {

--- a/src/image.js
+++ b/src/image.js
@@ -76,14 +76,8 @@ export default async (req, res) => {
   if (isNaN(t) || t < 0) {
     return res.status(400).send("Bad Request. Invalid param: t");
   }
-  const videoFile = path.join(
-    req.params.anilistID,
-    req.params.filename.replace(/\.jpg$/, "")
-  );
-  const videoFilePath = path.join(
-    VIDEO_PATH,
-    videoFile
-  );
+  const videoFile = path.join(req.params.anilistID, req.params.filename.replace(/\.jpg$/, ""));
+  const videoFilePath = path.join(VIDEO_PATH, videoFile);
   if (!videoFilePath.startsWith(VIDEO_PATH)) {
     return res.status(403).send("Forbidden");
   }

--- a/src/image.js
+++ b/src/image.js
@@ -101,8 +101,7 @@ export default async (req, res) => {
   try {
     const image = await generateImagePreview(videoFilePath, t, size);
 
-    const knex = req.app.locals.knex;
-    await logView(knex, videoFile, size, t);
+    logView(req.app.locals.knex, videoFile, size, t);
 
     res.set("Content-Type", "image/jpg");
     res.send(image);

--- a/src/video.js
+++ b/src/video.js
@@ -132,8 +132,6 @@ export default async (req, res) => {
   if (req.app.locals.mediaQueue > MEDIA_QUEUE) return res.status(503).send("Service Unavailable");
   req.app.locals.mediaQueue++;
 
-  const knex = req.app.locals.knex;
-
   try {
     const scene = await detectScene(videoFilePath, t, minDuration > 2 ? 2 : minDuration);
     if (scene === null) {
@@ -143,7 +141,7 @@ export default async (req, res) => {
     const muted = "mute" in req.query;
     const video = await generateVideoPreview(videoFilePath, scene.start, scene.end, size, muted);
 
-    await logView(knex, fileFile, scene, size, t, muted);
+    logView(req.app.locals.knex, fileFile, scene, size, t, muted);
 
     res.set("Content-Type", "video/mp4");
     res.set("x-video-start", scene.start);


### PR DESCRIPTION
Logging the viewed media allows for the creation of statistics. An example would be the most searched series and scenes.

These changes include:

- Fix in the searches log in SQLite when the search fails.
- Added scene preview log.
- Added scene thumbnail log.

This change requires an `id` to be present on the `files` table.

I have prepared and ran the following query manually to ensure the data in the database was properly converted. For new installs a migration is provided.

```SQL
CREATE TEMPORARY TABLE file_migration SELECT * FROM file;

DROP TABLE IF EXISTS `file`;

CREATE TABLE `file` (
  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
  `path` varchar(768) NOT NULL,
  `status` enum('UPLOADED','HASHING','HASHED','LOADING','LOADED') NOT NULL,
  `created` timestamp NOT NULL DEFAULT current_timestamp(),
  `updated` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
  PRIMARY KEY (`id`),
  UNIQUE KEY `path` (`path`),
  KEY `status` (`status`),
  KEY `created` (`created`),
  KEY `updated` (`updated`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

INSERT INTO file SELECT * FROM file_migration;
```