### PR TITLE
Switching to webp for preview thumbnails

### DIFF
--- a/src/image.js
+++ b/src/image.js
@@ -22,7 +22,7 @@ const generateImagePreview = async (filePath, t, size = "m") =>
       "-vf",
       `scale=${{ l: 640, m: 320, s: 160 }[size]}:-2`,
       "-c:v",
-      "mjpeg",
+      "libwebp",
       "-vframes",
       "1",
       "-f",
@@ -97,7 +97,7 @@ export default async (req, res) => {
 
     logView(req.app.locals.knex, videoFile, size, t);
 
-    res.set("Content-Type", "image/jpg");
+    res.set("Content-Type", "image/webp");
     res.send(image);
   } catch (e) {
     console.log(e);

--- a/src/search.js
+++ b/src/search.js
@@ -411,7 +411,7 @@ export default async (req, res) => {
       .replace(/[^0-9A-Za-z]/g, "");
     const imageToken = crypto
       .createHash("sha1")
-      .update([anilist_id, `${filename}.jpg`, mid, now, TRACE_API_SALT].join(""))
+      .update([anilist_id, `${filename}.webp`, mid, now, TRACE_API_SALT].join(""))
       .digest("base64")
       .replace(/[^0-9A-Za-z]/g, "");
 
@@ -427,7 +427,7 @@ export default async (req, res) => {
         `now=${now}`,
         `token=${videoToken}`,
       ].join("&")}`,
-      image: `${req.protocol}://${req.get("host")}/image/${anilist_id}/${encodeURIComponent(filename)}.jpg?${[
+      image: `${req.protocol}://${req.get("host")}/image/${anilist_id}/${encodeURIComponent(filename)}.webp?${[
         `t=${mid}`,
         `now=${now}`,
         `token=${imageToken}`,


### PR DESCRIPTION
WebP is baseline since 2020, it reduces bandwidth by 25% compared to jpg.