### PR TITLE
Fix unnecessary API calls when anilist_id is invalid

### DIFF
--- a/src/worker/analyze.ts
+++ b/src/worker/analyze.ts
@@ -17,41 +17,45 @@ try {
   process.exit(1);
 }
 
-const rows = await sql`
-  SELECT
-    id
-  FROM
-    anilist
-  WHERE
-    id = ${anilist_id}
-`;
-if (!rows.length) {
-  console.log(`Fetching anime info ID ${anilist_id} from anilist`);
-  const res = await fetch("https://graphql.anilist.co/", {
-    method: "POST",
-    body: JSON.stringify({
-      query: await fs.readFile(
-        path.join(import.meta.dirname, "../../script/anilist.graphql"),
-        "utf8",
-      ),
-      variables: { id: anilist_id },
-    }),
-    headers: { "Content-Type": "application/json" },
-  });
-  if (res.status === 200) {
-    const anime = (await res.json()).data.Page.media[0];
-    console.log(`Saving anime info ID ${anime.id} (${anime.title.native ?? anime.title.romaji})`);
-    await sql`
-      INSERT INTO
-        anilist (id, updated, json)
-      VALUES
-        (
-          ${Number(anime.id)},
-          now(),
-          ${anime}
-        )
-    `;
+if (anilist_id) {
+  const rows = await sql`
+    SELECT
+      id
+    FROM
+      anilist
+    WHERE
+      id = ${anilist_id}
+  `;
+  if (!rows.length) {
+    console.log(`Fetching anime info ID ${anilist_id} from anilist`);
+    const res = await fetch("https://graphql.anilist.co/", {
+      method: "POST",
+      body: JSON.stringify({
+        query: await fs.readFile(
+          path.join(import.meta.dirname, "../../script/anilist.graphql"),
+          "utf8",
+        ),
+        variables: { id: anilist_id },
+      }),
+      headers: { "Content-Type": "application/json" },
+    });
+    if (res.status === 200) {
+      const anime = (await res.json()).data.Page.media[0];
+      console.log(`Saving anime info ID ${anime.id} (${anime.title.native ?? anime.title.romaji})`);
+      await sql`
+        INSERT INTO
+          anilist (id, updated, json)
+        VALUES
+          (
+            ${Number(anime.id)},
+            now(),
+            ${anime}
+          )
+      `;
+    }
   }
+} else {
+  console.log(`Anilist ID not set for file: ${videoFilePath}`);
 }
 
 const start = performance.now();


### PR DESCRIPTION
A fix for API calls to anilist that will result in errors.

💡 What:

- Adds extra check on the `anilist_id` in `analyze.ts`  

🎯 Why:

- An unset id or 0 do not exists and result in an error response from anilist.