### PR TITLE
Add printing console error when scene detection is missing

### DIFF
--- a/src/video.ts
+++ b/src/video.ts
@@ -144,6 +144,7 @@ export default async (req, res) => {
       Math.min(Math.max(Number(req.query.maxDuration) || 5, 0.5), 5), // default: 5.0s before and after t, range: 0.5s ~ 5.0s
     );
     if (scene === null) {
+      console.error(`No scene could be detected for ${videoFilePath} @ ${time / 10000}`);
       return res.status(500).send("Internal Server Error");
     }
 


### PR DESCRIPTION
Saving time for the next one that forgets to put a `\` at the end of their `VIDEO_PATH` on Windows.