### PR TITLE
Ensure quotas are returned as numbers by the API.

### DIFF
--- a/src/get-me.ts
+++ b/src/get-me.ts
@@ -62,7 +62,7 @@ export default async (req, res) => {
     id,
     priority,
     concurrency,
-    quota,
-    quotaUsed,
+    quota: Number(quota),
+    quotaUsed: Number(quotaUsed),
   });
 };


### PR DESCRIPTION
`quotaUsed` is returned as a string for non-authenticated users.

See: https://api.trace.moe/me